### PR TITLE
Performance improvement CheckBlankModules

### DIFF
--- a/crhmcode/src/core/CRHMmain.cpp
+++ b/crhmcode/src/core/CRHMmain.cpp
@@ -2280,8 +2280,6 @@ void  CRHMmain::RunClick2Middle(MMSData * mmsdata, long startdate, long enddate)
 				//double tdiff = double(clock() - btime) / CLOCKS_PER_SEC; ///////////////////////////////////////////////////////////////
 				//ts->addTime("ReadObs", tdiff);
 
-				CheckBlankModule();
-
 				if (!p->isGroup || !Global::CRHMStatus || (Global::CRHMStatus & 1 && Global::ModuleBitSet->count(Global::CurrentModuleRun))) {
 					//try
 					//{
@@ -2298,8 +2296,6 @@ void  CRHMmain::RunClick2Middle(MMSData * mmsdata, long startdate, long enddate)
 					//	Common::writefile("d:/test.txt", "error in p = " + p->Name + ", p nameroot = " + p->NameRoot+" ");
 					//}
 				}
-
-				CheckBlankModule();
 
 				// module flag loop
 
@@ -2470,18 +2466,6 @@ void CRHMmain::RunClick2End(MMSData * mmsdata)
 
 	CRHMLogger::instance()->get_run_logger()->flush();
 
-}
-
-
-void CRHMmain::CheckBlankModule() {
-
-	MapVar::iterator itVar;
-	ClassVar * thisVar;
-
-	for (itVar = Global::MapVars.begin(); itVar != Global::MapVars.end(); itVar++) {
-		thisVar = (*itVar).second;
-		string s = thisVar->name;
-	}
 }
 
 


### PR DESCRIPTION
This routine seems to be providing no functionality but iterates over every CRHM variable and is called twice for every module on every time step.

Performance on one core of my CPU with Kevin's project file (see #372) is given below.

ORIGINAL
real    3m15.966s
user    2m9.290s
sys     1m6.573s

CORRECTED
real    2m39.832s
user    1m34.995s
sys     1m4.760s