### PR TITLE
Modify date conversion to be UTC always

### DIFF
--- a/crhmcode/src/core/StandardConverterUtility.cpp
+++ b/crhmcode/src/core/StandardConverterUtility.cpp
@@ -80,7 +80,7 @@ double StandardConverterUtility::Calculate_TdateTime_Offset(void) {  //Manishank
 	timeinfo.tm_year = 70;
 	timeinfo.tm_isdst = -1;
 
-	time_t Current = mktime(&timeinfo); // determine ???
+	time_t Current = timegm(&timeinfo); // determine ???
 
 	return double(Current) / 86400.0;
 }
@@ -102,7 +102,7 @@ double StandardConverterUtility::EncodeDateTime(int Year, int Month, int Day, in
 
 	timeinfo.tm_year = Year + Decade_Offsets[indx][0] - 1900;
 
-	time_t Current = mktime(&timeinfo);
+	time_t Current = timegm(&timeinfo);
 
 	return double(Current) / 86400.0 + Decade_Offsets[indx][1] - Calculate_TdateTime_Offset(); //Global::TdateTime_Offset; // correction from
 }


### PR DESCRIPTION
Previously decoding used UTC but encoding used local time as defined by the timezone file on the computer running the model. This causes problems if the computer's timezone has daylight savings, or if the timezone
information file is on a slow network drive.