### PR TITLE
Macro JULIAN should return whole number

### DIFF
--- a/crhmcode/src/core/ClassMacro.cpp
+++ b/crhmcode/src/core/ClassMacro.cpp
@@ -22,7 +22,7 @@ double Fyear() { // used for variable YEAR
 }
 
 double Fjulian() { // used for variable JULIAN
-	return Julian("now");
+	return julian("now");
 }
 
 double Fgetstep() { // used for variable STEP


### PR DESCRIPTION
This modification changes macro JULIAN to return a whole number rather than a decimal, in line with the original Borland code. I've attached a test proj/obs as well as old, new and borland output files. I've also tested this with Kevin's prj and it turns out to make no difference in practice so it is purely to avoid any potential future mismatch with the Borland version.
[output_borland.txt](https://github.com/srlabUsask/crhmcode/files/9125217/output_borland.txt)
[output_post.txt](https://github.com/srlabUsask/crhmcode/files/9125218/output_post.txt)
[lowercase_julian.zip](https://github.com/srlabUsask/crhmcode/files/9125220/lowercase_julian.zip)

[output_pre.txt](https://github.com/srlabUsask/crhmcode/files/9125219/output_pre.txt)

