### PR TITLE
Added a warning for CLI mode if env TZ is not set.

### DIFF
--- a/crhmcode/src/main.cpp
+++ b/crhmcode/src/main.cpp
@@ -9,6 +9,11 @@ int main(int argc, char *argv[])
     arguments->readCommandLine(argc, argv);
     arguments->validate();
 
+    int i = system("test -z $TZ && echo \"Enviroment variable TZ is not set this"
+     " may negatively impact performance.\n Set TZ to :[Timezone]\n You can find"
+     " the timezone to set TZ to in /etc/timezone on most systems.\n \" "
+     "|| echo \"TZ is set to $TZ\n\"");
+
     //Create main object with the given arguments.
     CRHMmain* m = new CRHMmain(arguments);
 
@@ -21,7 +26,7 @@ int main(int argc, char *argv[])
     }
     else
     {
-      std::cout << "Error encountered while loading the project. Check log file for more detail.";
+      std::cout << "Error encountered while loading the project. Check log file for more detail.\n";
     }
 
 }


### PR DESCRIPTION
This implements a warning that displays in CLI mode when the environment variable TZ is not set. The warning tells the user that performance may be impacted and encourages them to set the variable. If TZ is set the set timezone will be output. 

The portability of this needs to be checked on windows systems running the CLI. 

Setting the TZ variable positivity impacts performance on systems where the call to mktime() in StandardConverterUtility::Calculate_TdateTime_Offset and StandardConverterUtility::EncodeDateTime ends up calling the system utility tzset which uses the TZ environment variable. 

This implementation may not be good for all systems. 