### PR TITLE
Fix for NDEFN vars in Display_var project section

### DIFF
--- a/crhmcode/src/core/CRHMmain.cpp
+++ b/crhmcode/src/core/CRHMmain.cpp
@@ -2093,7 +2093,7 @@ std::string  CRHMmain::ExtractHruLay(std::string label, int &Hru, int &Lay)
 	
 	Lay = 0;
 
-	if (commaPos > -1)
+	if (commaPos != string::npos)
 	{
 		Lay = Strtolong(label.substr(commaPos + 1, closeParenPos - commaPos - 1));
 	}


### PR DESCRIPTION
string::find returns npos which is type size_t and = -1 
but size_t is unsigned so comparisons to negative values will always fail.