### PR TITLE
Crhm glacier infiltration module order correction 4 oct2023

### DIFF
--- a/crhmcode/src/modules/ClassAyers.h
+++ b/crhmcode/src/modules/ClassAyers.h
@@ -23,7 +23,7 @@
 class ClassAyers : public ClassModule {
 public:
 
-ClassAyers(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl) {};
+ClassAyers(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org") {}; // setting PeerRank, change on 04Oct2023
 
 // declared variables
 double *infil { NULL };

--- a/crhmcode/src/modules/ClassAyers.h
+++ b/crhmcode/src/modules/ClassAyers.h
@@ -23,7 +23,14 @@
 class ClassAyers : public ClassModule {
 public:
 
-ClassAyers(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org") {}; // setting PeerRank, change on 04Oct2023
+ClassAyers(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : 
+	ClassModule(
+		Name, 
+		Version, 
+		Lvl, 
+		1001, // Set PeerRank to ensure proper module ordering below glacier modules
+		"net_rain_org"
+	) {}; 
 
 // declared variables
 double *infil { NULL };

--- a/crhmcode/src/modules/ClassGreenAmpt.h
+++ b/crhmcode/src/modules/ClassGreenAmpt.h
@@ -24,7 +24,15 @@
 class ClassGreenAmpt : public ClassModule {
 public:
 
-ClassGreenAmpt(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org") {}; // setting PeerRank, change on 04Oct2023
+ClassGreenAmpt(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : 
+	ClassModule(
+		Name, 
+		Version, 
+		Lvl, 
+		1001, // Set PeerRank to ensure proper module ordering below glacier modules 
+		"net_rain_org"
+	) {};
+
 // declared variables
 double *infil{ NULL };
 double *cuminfil{ NULL };

--- a/crhmcode/src/modules/ClassGreenAmpt.h
+++ b/crhmcode/src/modules/ClassGreenAmpt.h
@@ -24,7 +24,7 @@
 class ClassGreenAmpt : public ClassModule {
 public:
 
-ClassGreenAmpt(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl) {};
+ClassGreenAmpt(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org") {}; // setting PeerRank, change on 04Oct2023
 // declared variables
 double *infil{ NULL };
 double *cuminfil{ NULL };

--- a/crhmcode/src/modules/ClassGreencrack.h
+++ b/crhmcode/src/modules/ClassGreencrack.h
@@ -24,9 +24,15 @@
 class ClassGreencrack : public ClassModule {
 public:
 
-ClassGreencrack(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org"), // setting PeerRank, change on 04Oct2023
-                                   Xinfil(NULL),
-                                   timer(NULL) {};
+ClassGreencrack(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : 
+    ClassModule(
+        Name, 
+        Version, 
+        Lvl, 
+        1001, // Set PeerRank to ensure proper module ordering below glacier modules
+        "net_rain_org"
+    ), Xinfil(NULL), timer(NULL) {};
+
 // declared variables
 double *infil{ NULL };
 double *cuminfil{ NULL };

--- a/crhmcode/src/modules/ClassGreencrack.h
+++ b/crhmcode/src/modules/ClassGreencrack.h
@@ -24,7 +24,7 @@
 class ClassGreencrack : public ClassModule {
 public:
 
-ClassGreencrack(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl),
+ClassGreencrack(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org"), // setting PeerRank, change on 04Oct2023
                                    Xinfil(NULL),
                                    timer(NULL) {};
 // declared variables

--- a/crhmcode/src/modules/ClassPrairieInfil.h
+++ b/crhmcode/src/modules/ClassPrairieInfil.h
@@ -23,9 +23,15 @@
 class ClassPrairieInfil : public ClassModule {
 public:
 
-ClassPrairieInfil(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org"), // setting PeerRank, change on 04Oct2023
-                                   Xinfil(NULL),
-                                   timer(NULL) {};
+ClassPrairieInfil(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : 
+    ClassModule(
+        Name, 
+        Version, 
+        Lvl, 
+        1001, // Set PeerRank to ensure proper module ordering below glacier modules
+        "net_rain_org"
+    ), Xinfil(NULL), timer(NULL) {};
+
 // declared variables
 double *snowinfil{ NULL };
 double *cumsnowinfil{ NULL };

--- a/crhmcode/src/modules/ClassPrairieInfil.h
+++ b/crhmcode/src/modules/ClassPrairieInfil.h
@@ -23,7 +23,7 @@
 class ClassPrairieInfil : public ClassModule {
 public:
 
-ClassPrairieInfil(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl),
+ClassPrairieInfil(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org"), // setting PeerRank, change on 04Oct2023
                                    Xinfil(NULL),
                                    timer(NULL) {};
 // declared variables

--- a/crhmcode/src/modules/Classcrack.h
+++ b/crhmcode/src/modules/Classcrack.h
@@ -23,7 +23,7 @@
 class Classcrack : public ClassModule {
 public:
 
-Classcrack(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl),
+Classcrack(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org"), // setting PeerRank, change on 04Oct2023
                                    Xinfil(NULL),
                                    timer(NULL) {};
 // declared variables

--- a/crhmcode/src/modules/Classcrack.h
+++ b/crhmcode/src/modules/Classcrack.h
@@ -23,9 +23,15 @@
 class Classcrack : public ClassModule {
 public:
 
-Classcrack(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org"), // setting PeerRank, change on 04Oct2023
-                                   Xinfil(NULL),
-                                   timer(NULL) {};
+Classcrack(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : 
+    ClassModule(
+        Name, 
+        Version, 
+        Lvl, 
+        1001, // Set PeerRank to ensure proper module ordering below glacier modules
+        "net_rain_org"
+    ), Xinfil(NULL), timer(NULL) {};
+
 // declared variables
 double *snowinfil { NULL };
 double *cumsnowinfil { NULL };

--- a/crhmcode/src/modules/Classfrozen.h
+++ b/crhmcode/src/modules/Classfrozen.h
@@ -23,7 +23,7 @@
 class Classfrozen : public ClassModule {
 public:
 
-Classfrozen(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl),
+Classfrozen(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org"), // setting PeerRank, change on 04Oct2023
                                     infiltype(NULL) {};
 bool SetOpportunityTime {false};
 bool Update_infil {false};

--- a/crhmcode/src/modules/Classfrozen.h
+++ b/crhmcode/src/modules/Classfrozen.h
@@ -23,8 +23,15 @@
 class Classfrozen : public ClassModule {
 public:
 
-Classfrozen(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org"), // setting PeerRank, change on 04Oct2023
-                                    infiltype(NULL) {};
+Classfrozen(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : 
+    ClassModule(
+        Name, 
+        Version, 
+        Lvl, 
+        1001, // Set PeerRank to ensure proper module ordering below glacier modules
+        "net_rain_org"
+    ), infiltype(NULL) {};
+
 bool SetOpportunityTime {false};
 bool Update_infil {false};
 

--- a/crhmcode/src/modules/ClassfrozenAyers.h
+++ b/crhmcode/src/modules/ClassfrozenAyers.h
@@ -23,7 +23,7 @@
 class ClassfrozenAyers : public ClassModule {
 public:
 
-ClassfrozenAyers(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl),
+ClassfrozenAyers(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org"), // setting PeerRank, change on 04Oct2023
                                     infiltype(NULL) {};
 bool SetOpportunityTime {false};
 bool Update_infil {false};

--- a/crhmcode/src/modules/ClassfrozenAyers.h
+++ b/crhmcode/src/modules/ClassfrozenAyers.h
@@ -23,8 +23,15 @@
 class ClassfrozenAyers : public ClassModule {
 public:
 
-ClassfrozenAyers(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : ClassModule(Name, Version, Lvl, 1001, "net_rain_org"), // setting PeerRank, change on 04Oct2023
-                                    infiltype(NULL) {};
+ClassfrozenAyers(string Name, string Version = "undefined", LMODULE Lvl = LMODULE::PROTO) : 
+    ClassModule(
+        Name, 
+        Version, 
+        Lvl, 
+        1001, // Set PeerRank to ensure proper module ordering below glacier modules
+        "net_rain_org"
+    ), infiltype(NULL) {};
+
 bool SetOpportunityTime {false};
 bool Update_infil {false};
 


### PR DESCRIPTION
Correction to module order between infiltration modules Ayers, frozenAyers, frozen, crack, Greencrack, GreenAmpt, and PrairieInfiltration and glacier when constructing model project in GUI. The .h files of these modules Ayers, frozenAyers, frozen, crack, Greencrack, GreenAmpt, and PrairieInfiltration have been modified to fix the module order issue. More details are included in Issue#433.