### PR TITLE
Added new output variable useful for canopy snow sublimation research

### DIFF
--- a/crhmcode/src/modules/ClassCRHMCanopyClearingGap.cpp
+++ b/crhmcode/src/modules/ClassCRHMCanopyClearingGap.cpp
@@ -138,6 +138,8 @@ void ClassCRHMCanopyClearingGap::decl(void) {
 
   declstatdiag("cum_net_rain", TDim::NHRU, "cumulative direct_rain + drip", "(mm)", &cum_net_rain);
 
+  declvar("pot_subl_cpy", TDim::NHRU, "potential dimensionless canopy snow sublimation rate", "(-)", &pot_subl_cpy);
+
   declvar("Subl_Cpy", TDim::NHRU, "canopy snow sublimation", "(mm/int)", &Subl_Cpy);
 
   declstatdiag("cum_Subl_Cpy", TDim::NHRU, "cumulative canopy snow sublimation", "(mm)", &cum_Subl_Cpy);
@@ -504,6 +506,8 @@ void ClassCRHMCanopyClearingGap::run(void){
 // sublimation rate of single 'ideal' ice sphere:
 
           double Vs = (2.0* M_PI* Radius*Sigma2 - SStar* J)/(Hs* J + C1)/Mpm;
+
+          pot_subl_cpy[hh] = Vs; // export the dimensionless potential sublimation rate added by alex 2023-07-21
 
 // snow exposure coefficient (Ce):
 

--- a/crhmcode/src/modules/ClassCRHMCanopyClearingGap.cpp
+++ b/crhmcode/src/modules/ClassCRHMCanopyClearingGap.cpp
@@ -138,7 +138,7 @@ void ClassCRHMCanopyClearingGap::decl(void) {
 
   declstatdiag("cum_net_rain", TDim::NHRU, "cumulative direct_rain + drip", "(mm)", &cum_net_rain);
 
-  declvar("pot_subl_cpy", TDim::NHRU, "potential dimensionless canopy snow sublimation rate", "(-)", &pot_subl_cpy);
+  declvar("pot_subl_cpy", TDim::NHRU, "dimensionless canopy snow sublimation rate aka potential sublimation rate to be multiplied by canopy snow load", "(s-1)", &pot_subl_cpy);
 
   declvar("Subl_Cpy", TDim::NHRU, "canopy snow sublimation", "(mm/int)", &Subl_Cpy);
 
@@ -507,7 +507,7 @@ void ClassCRHMCanopyClearingGap::run(void){
 
           double Vs = (2.0* M_PI* Radius*Sigma2 - SStar* J)/(Hs* J + C1)/Mpm;
 
-          pot_subl_cpy[hh] = Vs; // export the dimensionless potential sublimation rate added by alex 2023-07-21
+          pot_subl_cpy[hh] = Vs; // export the dimensionless sublimation rate (s-1) added by alex 2023-07-21
 
 // snow exposure coefficient (Ce):
 

--- a/crhmcode/src/modules/ClassCRHMCanopyClearingGap.h
+++ b/crhmcode/src/modules/ClassCRHMCanopyClearingGap.h
@@ -67,6 +67,7 @@ double *cum_net_snow { NULL };
 double *net_p { NULL };
 double *intcp_evap { NULL };
 double *cum_intcp_evap { NULL };
+double *pot_subl_cpy { NULL };
 double *Subl_Cpy { NULL };
 double *cum_Subl_Cpy { NULL };
 double *cum_SUnload { NULL };


### PR DESCRIPTION
The pot_subl_spy variable (already calculated by CRHM but was private) was added as a possible public output variable. This is the 'dimensionless canopy sublimation rate' in units per second. This variable  is used to multiple by the canopy snow load to calculate the sublimation of snow from the canopy. It is useful to output this variable to calculate canopy sublimation rate using the canopy snow load measured using a weighed tree lysimeter instead of the CRHM simulated canopy snow load.