### PR TITLE
Crhm canopy module adding potential sublimation varaible 14 nov2023

### DIFF
--- a/crhmcode/src/modules/ClassCRHMCanopy.cpp
+++ b/crhmcode/src/modules/ClassCRHMCanopy.cpp
@@ -129,6 +129,8 @@ void ClassCRHMCanopy::decl(void) {
 
   declstatdiag("cum_net_rain", TDim::NHRU, "cumulative direct_rain + drip", "(mm)", &cum_net_rain);
 
+  declvar("pot_subl_cpy", TDim::NHRU, "potential dimensionless canopy snow sublimation rate", "(s^-1)", &pot_subl_cpy);
+  
   declvar("Subl_Cpy", TDim::NHRU, "canopy snow sublimation", "(mm/int)", &Subl_Cpy);
 
   declstatdiag("cum_Subl_Cpy", TDim::NHRU, "cumulative canopy snow sublimation", "(mm)", &cum_Subl_Cpy);
@@ -413,6 +415,8 @@ void ClassCRHMCanopy::run(void) {
 // sublimation rate of single 'ideal' ice sphere:
 
       double Vs = (2.0* M_PI* Radius*Sigma2 - SStar* J)/(Hs* J + C1)/Mpm;
+
+      pot_subl_cpy[hh] = Vs; // 14Nov2023: export the dimensionless sublimation rate (s^-1)
 
 // snow exposure coefficient (Ce):
 

--- a/crhmcode/src/modules/ClassCRHMCanopy.h
+++ b/crhmcode/src/modules/ClassCRHMCanopy.h
@@ -65,6 +65,7 @@ double *cum_net_snow { NULL };
 double *net_p { NULL };
 double *intcp_evap { NULL };
 double *cum_intcp_evap { NULL };
+double *pot_subl_cpy { NULL };
 double *Subl_Cpy { NULL };
 double *cum_Subl_Cpy { NULL };
 double *cum_SUnload { NULL };

--- a/crhmcode/src/modules/ClassCRHMCanopyClearing.cpp
+++ b/crhmcode/src/modules/ClassCRHMCanopyClearing.cpp
@@ -133,6 +133,8 @@ void ClassCRHMCanopyClearing::decl(void) {
 
   declstatdiag("cum_net_rain", TDim::NHRU, "cumulative direct_rain + drip", "(mm)", &cum_net_rain);
 
+  declvar("pot_subl_cpy", TDim::NHRU, "potential dimensionless canopy snow sublimation rate", "(s^-1)", &pot_subl_cpy);
+  
   declvar("Subl_Cpy", TDim::NHRU, "canopy snow sublimation", "(mm/int)", &Subl_Cpy);
 
   declstatdiag("cum_Subl_Cpy", TDim::NHRU, "cumulative canopy snow sublimation", "(mm)", &cum_Subl_Cpy);
@@ -428,6 +430,8 @@ void ClassCRHMCanopyClearing::run(void) {
   // sublimation rate of single 'ideal' ice sphere:
 
           double Vs = (2.0* M_PI* Radius*Sigma2 - SStar* J)/(Hs* J + C1)/Mpm;
+
+          pot_subl_cpy[hh] = Vs; // 14Nov2023: export the dimensionless sublimation rate (s^-1)
 
   // snow exposure coefficient (Ce):
 

--- a/crhmcode/src/modules/ClassCRHMCanopyClearing.h
+++ b/crhmcode/src/modules/ClassCRHMCanopyClearing.h
@@ -67,6 +67,7 @@ double *cum_net_snow { NULL };
 double *net_p { NULL };
 double *intcp_evap { NULL };
 double *cum_intcp_evap { NULL };
+double *pot_subl_cpy { NULL };
 double *Subl_Cpy { NULL };
 double *cum_Subl_Cpy { NULL };
 double *cum_SUnload { NULL };


### PR DESCRIPTION
Adding variable "pot_subl_cpy" to output "dimensionless canopy sublimation rate" in Canopy, CanopyClearing modules, same as what Alex did for CanopyClearingGap.