### PR TITLE
Issue_448 Fix

### DIFF
--- a/crhmcode/vcc/gui/CRHMmainDlg.cpp
+++ b/crhmcode/vcc/gui/CRHMmainDlg.cpp
@@ -574,7 +574,7 @@ void CRHMmainDlg::RunClickFunction()
 	int TotalCount = 0;
 
 	int pcount = 0;
-	int last = 0;
+	int last = Global::DTmin;
 	for (int indx = Global::DTmin; indx < Global::DTmax; indx = last)
 	{
 


### PR DESCRIPTION
Setting last to start at Global::DTmin to ensure simulation starts at the right date.