### PR TITLE
Fixed inconsistency between GreenAmpt and GreenCrack modules August 20, 2024

### DIFF
--- a/crhmcode/src/modules/ClassGreenAmpt.cpp
+++ b/crhmcode/src/modules/ClassGreenAmpt.cpp
@@ -111,10 +111,12 @@ void ClassGreenAmpt::init(void) {
     cummeltrunoff[hh] = 0.0;
 
     F1[hh]        = soil_moist_max[hh];
+    F0[hh]        = F1[hh];
     k[hh]         = soilproperties[soil_type[hh]][KSAT];
     dthbot[hh]    = (1.0 - soil_moist_init[hh]/soil_moist_max[hh]);
     psidthbot[hh] = soilproperties[soil_type[hh]][PSI]*dthbot[hh];
     f1[hh]        = calcf1(F1[hh], psidthbot[hh]);
+    f0[hh]        = f1[hh];
   }
 }
 

--- a/crhmcode/src/modules/ClassGreenAmpt.cpp
+++ b/crhmcode/src/modules/ClassGreenAmpt.cpp
@@ -111,12 +111,10 @@ void ClassGreenAmpt::init(void) {
     cummeltrunoff[hh] = 0.0;
 
     F1[hh]        = soil_moist_max[hh];
-    F0[hh]        = F1[hh];
     k[hh]         = soilproperties[soil_type[hh]][KSAT];
     dthbot[hh]    = (1.0 - soil_moist_init[hh]/soil_moist_max[hh]);
     psidthbot[hh] = soilproperties[soil_type[hh]][PSI]*dthbot[hh];
     f1[hh]        = calcf1(F1[hh], psidthbot[hh]);
-    f0[hh]        = f1[hh];
   }
 }
 
@@ -212,6 +210,7 @@ void ClassGreenAmpt::finish(bool good) {
 void ClassGreenAmpt::infiltrate(void){
 
   F0[hh] = F1[hh];
+  f0[hh] = f1[hh];
 
   if(soil_type[hh] == 0) { // water!
     pond += garain;

--- a/crhmcode/src/modules/ClassGreenAmpt.cpp
+++ b/crhmcode/src/modules/ClassGreenAmpt.cpp
@@ -114,7 +114,7 @@ void ClassGreenAmpt::init(void) {
     k[hh]         = soilproperties[soil_type[hh]][KSAT];
     dthbot[hh]    = (1.0 - soil_moist_init[hh]/soil_moist_max[hh]);
     psidthbot[hh] = soilproperties[soil_type[hh]][PSI]*dthbot[hh];
-    f1[hh]        = calcf1(F1[hh], psidthbot[hh])*Global::Interval*24.0;
+    f1[hh]        = calcf1(F1[hh], psidthbot[hh]);
   }
 }
 
@@ -217,7 +217,7 @@ void ClassGreenAmpt::infiltrate(void){
   }
   pond = 0.0;
 
-  f0[hh] = calcf1(F0[hh], psidthbot[hh])*Global::Interval*24.0;
+  f0[hh] = calcf1(F0[hh], psidthbot[hh]);
 
   if(intensity > f0[hh]) {
     ponding();
@@ -226,7 +226,7 @@ void ClassGreenAmpt::infiltrate(void){
 
   F1[hh] = F0[hh] + garain;
 
-  f1[hh] = calcf1(F1[hh], psidthbot[hh])*Global::Interval*24.0;
+  f1[hh] = calcf1(F1[hh], psidthbot[hh]);
 
   if(intensity > f1[hh])
     startponding();

--- a/crhmcode/src/modules/ClassGreenAmpt.cpp
+++ b/crhmcode/src/modules/ClassGreenAmpt.cpp
@@ -210,7 +210,6 @@ void ClassGreenAmpt::finish(bool good) {
 void ClassGreenAmpt::infiltrate(void){
 
   F0[hh] = F1[hh];
-  f0[hh] = f1[hh];
 
   if(soil_type[hh] == 0) { // water!
     pond += garain;

--- a/crhmcode/src/modules/ClassGreenAmpt.cpp
+++ b/crhmcode/src/modules/ClassGreenAmpt.cpp
@@ -149,8 +149,6 @@ void ClassGreenAmpt::run(void) {
           F1[hh] = soil_moist[hh];
           dthbot[hh]    = (1.0 - soil_moist[hh]/soil_moist_max[hh]);
           psidthbot[hh] = soilproperties[soil_type[hh]][PSI]*dthbot[hh];
-          if(soil_type[hh] > 0) // not water!
-            f1[hh] = calcf1(F1[hh], psidthbot[hh])*Global::Interval*24.0; // infiltrate first interval rainfall
 
           infiltrate();
 

--- a/crhmcode/src/modules/ClassGreencrack.cpp
+++ b/crhmcode/src/modules/ClassGreencrack.cpp
@@ -169,7 +169,7 @@ void ClassGreencrack::init(void) {
     }
 
     psidthbot[hh] = soilproperties[soil_type[hh]][PSI]*dthbot[hh];
-    f1[hh]        = calcf1(F1[hh], psidthbot[hh])*Global::Interval*24.0;
+    f1[hh]        = calcf1(F1[hh], psidthbot[hh]);
   }
 }
 

--- a/crhmcode/src/modules/ClassGreencrack.cpp
+++ b/crhmcode/src/modules/ClassGreencrack.cpp
@@ -299,8 +299,6 @@ void ClassGreencrack::run(void) {
           F1[hh] = soil_moist[hh];
           dthbot[hh]    = (1.0 - soil_moist[hh]/soil_moist_max[hh]);
           psidthbot[hh] = soilproperties[soil_type[hh]][PSI]*dthbot[hh];
-          if(soil_type[hh] > 0) // not water!
-            f1[hh] = calcf1(F1[hh], psidthbot[hh])*Global::Interval*24.0; // infiltrate first interval rainfall (mm/h)
 
           infiltrate();
 


### PR DESCRIPTION
The CRHM modules [GreenAmpt](https://github.com/srlabUsask/crhmcode/blob/master/crhmcode/src/modules/ClassGreenAmpt.cpp) and [GreenCrack](https://github.com/srlabUsask/crhmcode/blob/master/crhmcode/src/modules/ClassGreencrack.cpp) both use the Green-Ampt model for calculating infiltration. There is an inconsistency between these two modules in how the `f1` and `f0` variables are evaluated in the `Infiltrate` member function.

In GreenAmpt, `f1` and `f0` are both mulitplied by `Global::Interval*24.0` on lines [232](https://github.com/srlabUsask/crhmcode/blob/5fe48ed19281e9f8dc1b6307a49a7a21f435a84b/crhmcode/src/modules/ClassGreenAmpt.cpp#L232) and [223](https://github.com/srlabUsask/crhmcode/blob/5fe48ed19281e9f8dc1b6307a49a7a21f435a84b/crhmcode/src/modules/ClassGreenAmpt.cpp#L223), respectively. In the GreenCrack module, lines [352](https://github.com/srlabUsask/crhmcode/blob/5fe48ed19281e9f8dc1b6307a49a7a21f435a84b/crhmcode/src/modules/ClassGreencrack.cpp#L352) and [361](https://github.com/srlabUsask/crhmcode/blob/5fe48ed19281e9f8dc1b6307a49a7a21f435a84b/crhmcode/src/modules/ClassGreencrack.cpp#L361) there is no `Global::Interval*24.0` factor.

I've discussed this issue with John Pomeroy who has agreed that this is an issue. It will be fixed with the changes suggested in this PR in the e50890fd6c10c4d4b312094a454cdfdfc0e5ebcc commit. The other commits clean up some other issues related to the variables `f1` and `f0` in regards to their initialization.

Attached is a document describing the issue in detail.

[UnitsIssue.pdf](https://github.com/user-attachments/files/16682826/UnitsIssue.pdf)
