### PR TITLE
Crhm frozen frozen ayers info correction27 aug2024

### DIFF
--- a/crhmcode/src/modules/Classfrozen.cpp
+++ b/crhmcode/src/modules/Classfrozen.cpp
@@ -244,7 +244,7 @@ void Classfrozen::run(void) {
               INF[hh] = C[hh]*pow(S0[hh], 2.92f)*pow(1.0f-Si[hh], 1.64f)*
                    pow((273.15f-hru_tsoil[hh])/273.15f, -0.45f)*pow(t0_Var[hh], 0.44f); // (mm)
 
-              double INF0 = INF[hh]/t0_Var[hh];
+              double INF0 = INF[hh]/t0_Var[hh]*24.0/Global::Freq;
 
               if(snowmelt <= INF0 && snowmelt <= capacity) {
                 snowinfil[hh] = snowmelt;

--- a/crhmcode/src/modules/ClassfrozenAyers.cpp
+++ b/crhmcode/src/modules/ClassfrozenAyers.cpp
@@ -261,7 +261,7 @@ void ClassfrozenAyers::run(void) {
               INF[hh] = C[hh]*pow(S0[hh], 2.92f)*pow(1.0f-Si[hh], 1.64f)*
                    pow((273.15f-hru_tsoil[hh])/273.15f, -0.45f)*pow(t0_Var[hh], 0.44f); // (mm)
 
-              double INF0 = INF[hh]/t0_Var[hh];
+              double INF0 = INF[hh]/t0_Var[hh]*24.0/Global::Freq;
 
               if(snowmelt <= INF0 && snowmelt <= capacity) {
                 snowinfil[hh] = snowmelt;


### PR DESCRIPTION
In Classfrozen and ClassforzenAyers,

add *24.0/Global::Freq to INFO equation to make it more robust, because INFO should be in same unit when comparing to snowmelt, ie. mm/int not mm/h