### PR TITLE
Crhm xg module corrections 29 apr 7 may2025

### DIFF
--- a/crhmcode/src/modules/ClassXG.cpp
+++ b/crhmcode/src/modules/ClassXG.cpp
@@ -519,7 +519,7 @@ void ClassXG::run(void) {
                 double Last = last_front();
                 if(Last > 0.0){ // thaw front
                   Zdt[hh] = pop_front();
-                  find_thaw_D(Zdf[hh]);
+                  find_thaw_D(Zdt[hh]);
                   Zd_front_array[1][hh] = Zdt[hh];
                 }
                 else if(Last < 0.0){ // never two frozen fronts together

--- a/crhmcode/src/modules/ClassXG.cpp
+++ b/crhmcode/src/modules/ClassXG.cpp
@@ -857,7 +857,7 @@ void ClassXG::finish(bool good) {
 
 double ClassXG::get_ftc_lay(long lay){ // unfrozen(thawed) soil to be frozen
   if(calc_coductivity[hh]){
-    return (soil_solid_km_ki_lay[lay][hh] - soil_solid_km_lay[lay][hh])*sqr(h2o_lay[lay][hh]/(1000.0*por_lay[lay][hh])) + soil_solid_km_lay[lay][hh];
+    return (soil_solid_km_kw_lay[lay][hh] - soil_solid_km_lay[lay][hh])*sqr(h2o_lay[lay][hh]/(1000.0*por_lay[lay][hh])) + soil_solid_km_lay[lay][hh];
   }
   else
     return (1.0 - por_lay[lay][hh])*soil_solid_km_lay[lay][hh] + h2o_lay[lay][hh]/1000.0*kw + (por_lay[lay][hh] - h2o_lay[lay][hh]/1000.0)*ka;


### PR DESCRIPTION
Apr 7, 2025: Correcting get_ftc_lay() for calculating thermal conductivity using Johansen 1975 equation. soil_solid_km_kw_lay replaced soil_solid_km_ki_lay.

May 7, 2025: Correcting find_thaw_D() function by using Zdt, replacing previously mistaken variable Zdf used in the function; this is done for check thaw front block.