### PR TITLE
CRHM command line start date fix

### DIFF
--- a/crhmcode/src/core/CRHMmain.cpp
+++ b/crhmcode/src/core/CRHMmain.cpp
@@ -2308,7 +2308,7 @@ MMSData *  CRHMmain::RunClick2Start()
 		}
 	}
 
-
+	
 	Global::DTmin = (int)((DTstartR - Global::DTstart)* Global::Freq);
 	Global::DTindx = Global::DTmin;
 	Global::DTnow = Global::DTstart + Global::Interval*((long long)Global::DTindx + 1ll);
@@ -2351,13 +2351,19 @@ MMSData *  CRHMmain::RunClick2Start()
 		GoodRun = false;
 	}
 
-
+	
 	ClassData * FileData = NULL;
 	if (ObsFilesList->size() > 0)
 	{
 		FileData = ObsFilesList->begin()->second;
+		const double tolerance = 1e-9; // to handle floating point precision when DTstartR and FileData->Dt1 are effectively equal but have slightly different precision and then entered the first if statement below.
 
-		if (DTstartR < FileData->Dt1) {
+		if (fabs(DTstartR - FileData->Dt1) < tolerance) { // check if effectively equal 
+
+			LogMessageX("DTstartR and FileData->Dt1 are effectively equal but there still may be a small difference due to floating point precision");
+		
+		} else if (DTstartR < FileData->Dt1 - tolerance) {
+
 			LogMessageX("Start Time before first Observation");
 			GoodRun = false;
 		}


### PR DESCRIPTION
This seems to fix issue where CRHM would segfault with error `Start Time before first Observation` when comparing obs file start date to prj file start dates when compiled using: 

gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0

More details at issue https://github.com/issues/created?q=is%3Aissue+author%3A%40me+sort%3Aupdated-desc&issue=srlabUsask%7Ccrhmcode%7C460